### PR TITLE
Mock blocks message

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -104,3 +104,11 @@ func Max[T constraints.Ordered](a, b T) T {
 	}
 	return b
 }
+
+func Map[T any, U any](ts []T, mapper func(T) U) []U {
+	var result = make([]U, len(ts))
+	for i, v := range ts {
+		result[i] = mapper(v)
+	}
+	return result
+}


### PR DESCRIPTION
Use new messages.BlocksMessage instead of ad-hoc struct in core_test; implement serialization/deserialization and fake network delay in order to make tests more realistic.