### PR TITLE
move batch code into 'batch' package

### DIFF
--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -69,13 +69,13 @@ func makeBloom(capacity uint) filter.Filter[mock.BlockId] {
 }
 
 type BlockChannel struct {
-	channel  chan *messages.BlocksMessage[mock.BlockId, *mock.BlockId, BatchState]
-	receiver BatchBlockReceiver[mock.BlockId]
+	channel  chan *messages.BlocksMessage[mock.BlockId, *mock.BlockId, batch.BatchState]
+	receiver batch.BatchBlockReceiver[mock.BlockId]
 	rate     int64 // number of bytes transmitted per millisecond
 	latency  int64 // latency in milliseconds
 }
 
-func (ch *BlockChannel) SendList(state BatchState, blocks []RawBlock[mock.BlockId]) error {
+func (ch *BlockChannel) SendList(state batch.BatchState, blocks []RawBlock[mock.BlockId]) error {
 	message := messages.NewBlocksMessage(state, blocks)
 	if ch.rate > 0 || ch.latency > 0 {
 		buf := bytes.Buffer{}
@@ -95,7 +95,7 @@ func (ch *BlockChannel) Close() error {
 	return nil
 }
 
-func (ch *BlockChannel) SetBlockListener(receiver BatchBlockReceiver[mock.BlockId]) {
+func (ch *BlockChannel) SetBlockListener(receiver batch.BatchBlockReceiver[mock.BlockId]) {
 	ch.receiver = receiver
 }
 
@@ -112,14 +112,14 @@ func (ch *BlockChannel) listen() error {
 }
 
 type StatusChannel struct {
-	channel  chan *messages.StatusMessage[mock.BlockId, *mock.BlockId, BatchState]
-	receiver *SimpleBatchStatusReceiver[mock.BlockId]
+	channel  chan *messages.StatusMessage[mock.BlockId, *mock.BlockId, batch.BatchState]
+	receiver *batch.SimpleBatchStatusReceiver[mock.BlockId]
 	rate     int64 // number of bytes transmitted per millisecond
 	latency  int64 // latency in milliseconds
 }
 
-func (ch *StatusChannel) SendStatus(state BatchState, have filter.Filter[mock.BlockId], want []mock.BlockId) error {
-	var message *messages.StatusMessage[mock.BlockId, *mock.BlockId, BatchState]
+func (ch *StatusChannel) SendStatus(state batch.BatchState, have filter.Filter[mock.BlockId], want []mock.BlockId) error {
+	var message *messages.StatusMessage[mock.BlockId, *mock.BlockId, batch.BatchState]
 	if ch.rate > 0 || ch.latency > 0 {
 		message = messages.NewStatusMessage(state, have, want)
 		buf := bytes.Buffer{}
@@ -141,7 +141,7 @@ func (ch *StatusChannel) Close() error {
 	return nil
 }
 
-func (ch *StatusChannel) SetStatusListener(receiver *SimpleBatchStatusReceiver[mock.BlockId]) {
+func (ch *StatusChannel) SetStatusListener(receiver *batch.SimpleBatchStatusReceiver[mock.BlockId]) {
 	ch.receiver = receiver
 }
 
@@ -160,10 +160,10 @@ func (ch *StatusChannel) listen() error {
 
 type MockStatusSender struct {
 	channel      *StatusChannel
-	orchestrator Orchestrator[BatchState]
+	orchestrator Orchestrator[batch.BatchState]
 }
 
-func NewMockStatusSender(channel *StatusChannel, orchestrator Orchestrator[BatchState]) *MockStatusSender {
+func NewMockStatusSender(channel *StatusChannel, orchestrator Orchestrator[batch.BatchState]) *MockStatusSender {
 	return &MockStatusSender{
 		channel,
 		orchestrator,
@@ -195,14 +195,14 @@ func MockBatchTransfer(sender_store *mock.Store, receiver_store *mock.Store, roo
 	snapshotBefore := stats.GLOBAL_REPORTING.Snapshot()
 
 	blockChannel := BlockChannel{
-		make(chan *messages.BlocksMessage[mock.BlockId, *mock.BlockId, BatchState]),
+		make(chan *messages.BlocksMessage[mock.BlockId, *mock.BlockId, batch.BatchState]),
 		nil,
 		bytes_per_ms,
 		latency_ms,
 	}
 
 	statusChannel := StatusChannel{
-		make(chan *messages.StatusMessage[mock.BlockId, *mock.BlockId, BatchState]),
+		make(chan *messages.StatusMessage[mock.BlockId, *mock.BlockId, batch.BatchState]),
 		nil,
 		bytes_per_ms,
 		latency_ms,
@@ -405,14 +405,14 @@ func TestSessionQuiescence(t *testing.T) {
 	snapshotBefore := stats.GLOBAL_REPORTING.Snapshot()
 
 	blockChannel := BlockChannel{
-		make(chan *messages.BlocksMessage[mock.BlockId, *mock.BlockId, BatchState]),
+		make(chan *messages.BlocksMessage[mock.BlockId, *mock.BlockId, batch.BatchState]),
 		nil,
 		0,
 		0,
 	}
 
 	statusChannel := StatusChannel{
-		make(chan *messages.StatusMessage[mock.BlockId, *mock.BlockId, BatchState]),
+		make(chan *messages.StatusMessage[mock.BlockId, *mock.BlockId, batch.BatchState]),
 		nil,
 		0,
 		0,

--- a/http/server.go
+++ b/http/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/fission-codes/go-car-mirror/batch"
 	"github.com/fission-codes/go-car-mirror/core"
 	"github.com/fission-codes/go-car-mirror/core/instrumented"
 	"github.com/fission-codes/go-car-mirror/filter"
@@ -21,12 +22,12 @@ type SessionToken string
 
 type ServerSourceSessionData[I core.BlockId, R core.BlockIdRef[I]] struct {
 	conn    *HttpServerSourceConnection[I, R]
-	Session *core.SourceSession[I, core.BatchState]
+	Session *core.SourceSession[I, batch.BatchState]
 }
 
 type ServerSinkSessionData[I core.BlockId, R core.BlockIdRef[I]] struct {
 	conn    *HttpServerSinkConnection[I, R]
-	Session *core.SinkSession[I, core.BatchState]
+	Session *core.SinkSession[I, batch.BatchState]
 }
 
 type Server[I core.BlockId, R core.BlockIdRef[I]] struct {
@@ -174,7 +175,7 @@ func (srv *Server[I, R]) HandleStatus(response http.ResponseWriter, request *htt
 	log.Debugw("have session for token", "object", "Server", "method", "HandleStatus", "session", sessionToken)
 
 	// Parse the request to get the status message
-	message := messages.StatusMessage[I, R, core.BatchState]{}
+	message := messages.StatusMessage[I, R, batch.BatchState]{}
 	messageReader := bufio.NewReader(request.Body)
 	if err := message.Read(messageReader); err != nil {
 		log.Errorw("parsing status message", "object", "Server", "method", "HandleStatus", "session", sessionToken, "error", err)
@@ -279,7 +280,7 @@ func (srv *Server[I, R]) HandleBlocks(response http.ResponseWriter, request *htt
 	log.Debugw("have session for token", "object", "Server", "method", "HandleBlocks", "session", sessionToken)
 
 	// Parse the request to get the blocks message
-	message := messages.BlocksMessage[I, R, core.BatchState]{}
+	message := messages.BlocksMessage[I, R, batch.BatchState]{}
 	messageReader := bufio.NewReader(request.Body)
 	if err := message.Read(messageReader); err != io.EOF {
 		log.Errorw("parsing blocks message", "object", "Server", "method", "HandleBlocks", "session", sessionToken, "error", err)
@@ -314,7 +315,7 @@ func (srv *Server[I, R]) SourceSessions() []SessionToken {
 	return srv.sourceSessions.Keys()
 }
 
-func (srv *Server[I, R]) SourceInfo(token SessionToken) (*core.SourceSessionInfo[core.BatchState], error) {
+func (srv *Server[I, R]) SourceInfo(token SessionToken) (*core.SourceSessionInfo[batch.BatchState], error) {
 	if session, ok := srv.sourceSessions.Get(token); ok {
 		return session.Session.Info(), nil
 	} else {
@@ -326,7 +327,7 @@ func (srv *Server[I, R]) SinkSessions() []SessionToken {
 	return srv.sinkSessions.Keys()
 }
 
-func (srv *Server[I, R]) SinkInfo(token SessionToken) (*core.SinkSessionInfo[core.BatchState], error) {
+func (srv *Server[I, R]) SinkInfo(token SessionToken) (*core.SinkSessionInfo[batch.BatchState], error) {
 	if session, ok := srv.sinkSessions.Get(token); ok {
 		return session.Session.Info(), nil
 	} else {


### PR DESCRIPTION
Tidying up. Now that there is a 'batch' package (which was required to avoid a cyclic dependency) the rest of the batch-related things should go into it.