### PR TITLE
Successful transfers over HTTP

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -196,9 +196,7 @@ func (sbbs *SimpleBatchBlockSender[I]) Close() error {
 
 // Flush sends the current batch of blocks.
 func (sbbs *SimpleBatchBlockSender[I]) Flush() error {
-
-	batchState := sbbs.orchestrator.State()
-	if batchState&(SOURCE_SENDING) != 0 {
+	if sbbs.Len() > 0 {
 		sbbs.listMutex.Lock()
 		defer sbbs.listMutex.Unlock()
 

--- a/batch/connection.go
+++ b/batch/connection.go
@@ -4,20 +4,37 @@ import (
 	"github.com/fission-codes/go-car-mirror/core"
 	"github.com/fission-codes/go-car-mirror/core/instrumented"
 	"github.com/fission-codes/go-car-mirror/filter"
+	"github.com/fission-codes/go-car-mirror/messages"
 	"github.com/fission-codes/go-car-mirror/stats"
 )
 
-type GenericBatchSourceConnection[I core.BlockId] struct {
+type GenericBatchSourceConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 	core.Orchestrator[BatchState]
 	instrument instrumented.InstrumentationOptions
 	stats      stats.Stats
+	messages   chan *messages.BlocksMessage[I, R]
 }
 
-func (conn *GenericBatchSourceConnection[I]) Receiver(session *core.SourceSession[I, BatchState]) *SimpleBatchStatusReceiver[I] {
+func NewGenericBatchSourceConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSourceConnection[I, R] {
+	var orchestrator core.Orchestrator[BatchState] = NewBatchSourceOrchestrator()
+
+	if instrument&instrumented.INSTRUMENT_ORCHESTRATOR != 0 {
+		orchestrator = instrumented.NewOrchestrator(orchestrator, stats.WithContext("SourceOrchestrator"))
+	}
+
+	return &GenericBatchSourceConnection[I, R]{
+		orchestrator,
+		instrument,
+		stats,
+		make(chan *messages.BlocksMessage[I, R]),
+	}
+}
+
+func (conn *GenericBatchSourceConnection[I, R]) Receiver(session *core.SourceSession[I, BatchState]) *SimpleBatchStatusReceiver[I] {
 	return NewSimpleBatchStatusReceiver[I](session, conn)
 }
 
-func (conn *GenericBatchSourceConnection[I]) Sender(batchSender BatchBlockSender[I], batchSize uint32) core.BlockSender[I] {
+func (conn *GenericBatchSourceConnection[I, R]) Sender(batchSender BatchBlockSender[I], batchSize uint32) core.BlockSender[I] {
 	var sender core.BlockSender[I] = NewSimpleBatchBlockSender(batchSender, conn, batchSize)
 	if conn.instrument&instrumented.INSTRUMENT_SENDER != 0 {
 		sender = instrumented.NewBlockSender(sender, conn.stats.WithContext("BlockSender"))
@@ -25,48 +42,30 @@ func (conn *GenericBatchSourceConnection[I]) Sender(batchSender BatchBlockSender
 	return sender
 }
 
-func (conn *GenericBatchSourceConnection[I]) Session(store core.BlockStore[I], filter filter.Filter[I], requester bool) *core.SourceSession[I, BatchState] {
+func (conn *GenericBatchSourceConnection[I, R]) Session(store core.BlockStore[I], filter filter.Filter[I], requester bool) *core.SourceSession[I, BatchState] {
 	return instrumented.NewSourceSession[I, BatchState](store, filter, conn, conn.stats, conn.instrument, requester)
 }
 
-func NewGenericBatchSourceConnection[I core.BlockId](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSourceConnection[I] {
-
-	var orchestrator core.Orchestrator[BatchState] = NewBatchSourceOrchestrator()
-
-	if instrument&instrumented.INSTRUMENT_ORCHESTRATOR != 0 {
-		orchestrator = instrumented.NewOrchestrator(orchestrator, stats.WithContext("SourceOrchestrator"))
-	}
-
-	return &GenericBatchSourceConnection[I]{
-		orchestrator,
-		instrument,
-		stats,
-	}
+func (conn *GenericBatchSourceConnection[I, R]) DeferredSender(batchSize uint32) core.BlockSender[I] {
+	return conn.Sender(&ResponseBatchBlockSender[I, R]{conn.messages}, batchSize)
 }
 
-type GenericBatchSinkConnection[I core.BlockId] struct {
+func (conn *GenericBatchSourceConnection[I, R]) DeferredBatchSender() BatchBlockSender[I] {
+	return &ResponseBatchBlockSender[I, R]{conn.messages}
+}
+
+func (conn *GenericBatchSourceConnection[I, R]) PendingResponse() *messages.BlocksMessage[I, R] {
+	return <-conn.messages
+}
+
+type GenericBatchSinkConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 	core.Orchestrator[BatchState]
 	instrument instrumented.InstrumentationOptions
 	stats      stats.Stats
+	messages   chan *messages.StatusMessage[I, R]
 }
 
-func (conn *GenericBatchSinkConnection[I]) Receiver(session *core.SinkSession[I, BatchState]) *SimpleBatchBlockReceiver[I] {
-	return NewSimpleBatchBlockReceiver[I](session, conn)
-}
-
-// TODO: This really just instruments now, nothing else.
-func (conn *GenericBatchSinkConnection[I]) Sender(statusSender core.StatusSender[I]) core.StatusSender[I] {
-	if conn.instrument&instrumented.INSTRUMENT_SENDER != 0 {
-		statusSender = instrumented.NewStatusSender(statusSender, conn.stats)
-	}
-	return statusSender
-}
-
-func (conn *GenericBatchSinkConnection[I]) Session(store core.BlockStore[I], accumulator core.StatusAccumulator[I], requester bool) *core.SinkSession[I, BatchState] {
-	return instrumented.NewSinkSession[I, BatchState](store, accumulator, conn, conn.stats, conn.instrument, requester)
-}
-
-func NewGenericBatchSinkConnection[I core.BlockId](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSinkConnection[I] {
+func NewGenericBatchSinkConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSinkConnection[I, R] {
 
 	var orchestrator core.Orchestrator[BatchState] = NewBatchSinkOrchestrator()
 
@@ -74,9 +73,70 @@ func NewGenericBatchSinkConnection[I core.BlockId](stats stats.Stats, instrument
 		orchestrator = instrumented.NewOrchestrator(orchestrator, stats.WithContext("SinkOrchestrator"))
 	}
 
-	return &GenericBatchSinkConnection[I]{
+	return &GenericBatchSinkConnection[I, R]{
 		orchestrator,
 		instrument,
 		stats,
+		make(chan *messages.StatusMessage[I, R]),
 	}
+}
+
+func (conn *GenericBatchSinkConnection[I, R]) Receiver(session *core.SinkSession[I, BatchState]) *SimpleBatchBlockReceiver[I] {
+	return NewSimpleBatchBlockReceiver[I](session, conn)
+}
+
+// TODO: This really just instruments now, nothing else.
+func (conn *GenericBatchSinkConnection[I, R]) Sender(statusSender core.StatusSender[I]) core.StatusSender[I] {
+	if conn.instrument&instrumented.INSTRUMENT_SENDER != 0 {
+		statusSender = instrumented.NewStatusSender(statusSender, conn.stats)
+	}
+	return statusSender
+}
+
+func (conn *GenericBatchSinkConnection[I, R]) Session(store core.BlockStore[I], accumulator core.StatusAccumulator[I], requester bool) *core.SinkSession[I, BatchState] {
+	return instrumented.NewSinkSession[I, BatchState](store, accumulator, conn, conn.stats, conn.instrument, requester)
+}
+
+func (conn *GenericBatchSinkConnection[I, R]) DeferredBatchSender() core.StatusSender[I] {
+	return &ResponseStatusSender[I, R]{conn.messages}
+}
+
+func (conn *GenericBatchSinkConnection[I, R]) DeferredSender() core.StatusSender[I] {
+	return conn.Sender(&ResponseStatusSender[I, R]{conn.messages})
+}
+
+func (conn *GenericBatchSinkConnection[I, R]) PendingResponse() *messages.StatusMessage[I, R] {
+	return <-conn.messages
+}
+
+type ResponseBatchBlockSender[I core.BlockId, R core.BlockIdRef[I]] struct {
+	messages chan<- *messages.BlocksMessage[I, R]
+}
+
+func (bbs *ResponseBatchBlockSender[I, R]) SendList(blocks []core.RawBlock[I]) error {
+	log.Debugw("ResponseBatchBlockSender - enter", "method", "SendList", "blocks", len(blocks))
+	bbs.messages <- messages.NewBlocksMessage[I, R](blocks)
+	log.Debugw("ResponseBatchBlockSender - exit", "method", "SendList")
+	return nil
+}
+
+func (bbs *ResponseBatchBlockSender[I, R]) Close() error {
+	close(bbs.messages)
+	return nil
+}
+
+type ResponseStatusSender[I core.BlockId, R core.BlockIdRef[I]] struct {
+	messages chan<- *messages.StatusMessage[I, R]
+}
+
+func (ss *ResponseStatusSender[I, R]) SendStatus(have filter.Filter[I], want []I) error {
+	log.Debugw("enter", "object", "ResponseStatusSender", "method", "SendStatus", "have", have.Count(), "want", len(want))
+	ss.messages <- messages.NewStatusMessage[I, R](have, want)
+	log.Debugw("exit", "object", "ResponseStatusSender", "method", "SendStatus")
+	return nil
+}
+
+func (ss *ResponseStatusSender[I, R]) Close() error {
+	close(ss.messages)
+	return nil
 }

--- a/batch/connection.go
+++ b/batch/connection.go
@@ -15,8 +15,8 @@ type GenericBatchSourceConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 	messages   chan *messages.BlocksMessage[I, R]
 }
 
-func NewGenericBatchSourceConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSourceConnection[I, R] {
-	var orchestrator core.Orchestrator[BatchState] = NewBatchSourceOrchestrator()
+func NewGenericBatchSourceConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions, requester bool) *GenericBatchSourceConnection[I, R] {
+	var orchestrator core.Orchestrator[BatchState] = NewBatchSourceOrchestrator(requester)
 
 	if instrument&instrumented.INSTRUMENT_ORCHESTRATOR != 0 {
 		orchestrator = instrumented.NewOrchestrator(orchestrator, stats.WithContext("SourceOrchestrator"))
@@ -28,6 +28,11 @@ func NewGenericBatchSourceConnection[I core.BlockId, R core.BlockIdRef[I]](stats
 		stats,
 		make(chan *messages.BlocksMessage[I, R]),
 	}
+}
+
+// IsRequester returns true if the connection is a requester.
+func (conn *GenericBatchSourceConnection[I, R]) IsRequester() bool {
+	return conn.Orchestrator.IsRequester()
 }
 
 func (conn *GenericBatchSourceConnection[I, R]) Receiver(session *core.SourceSession[I, BatchState]) *SimpleBatchStatusReceiver[I] {
@@ -65,9 +70,9 @@ type GenericBatchSinkConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 	messages   chan *messages.StatusMessage[I, R]
 }
 
-func NewGenericBatchSinkConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSinkConnection[I, R] {
+func NewGenericBatchSinkConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions, requester bool) *GenericBatchSinkConnection[I, R] {
 
-	var orchestrator core.Orchestrator[BatchState] = NewBatchSinkOrchestrator()
+	var orchestrator core.Orchestrator[BatchState] = NewBatchSinkOrchestrator(requester)
 
 	if instrument&instrumented.INSTRUMENT_ORCHESTRATOR != 0 {
 		orchestrator = instrumented.NewOrchestrator(orchestrator, stats.WithContext("SinkOrchestrator"))

--- a/batch/connection.go
+++ b/batch/connection.go
@@ -33,49 +33,49 @@ func (snd *SimpleBatchStatusSender[I]) Close() error {
 // The requestor for sending blocks or status needs to only send when the session should continue running.
 // TODO: Add docs.
 
-type GenericRequestBatchBlockSender[I core.BlockId, S BatchBlockSender[I]] struct {
-	sender S
-}
+// type GenericRequestBatchBlockSender[I core.BlockId, S BatchBlockSender[I]] struct {
+// 	sender S
+// }
 
-func NewGenericRequestBatchBlockSender[I core.BlockId, S BatchBlockSender[I]](sender S) *GenericRequestBatchBlockSender[I, S] {
-	return &GenericRequestBatchBlockSender[I, S]{sender}
-}
+// func NewGenericRequestBatchBlockSender[I core.BlockId, S BatchBlockSender[I]](sender S) *GenericRequestBatchBlockSender[I, S] {
+// 	return &GenericRequestBatchBlockSender[I, S]{sender}
+// }
 
-func (bbs *GenericRequestBatchBlockSender[I, S]) SendList(state BatchState, blocks []core.RawBlock[I]) error {
-	// We never send block requests for empty batches.
-	if len(blocks) == 0 {
-		log.Debugw("exit", "object", "GenericRequestBatchBlockSender", "method", "SendList", "state", state, "blocks", len(blocks))
-		return nil
-	}
+// func (bbs *GenericRequestBatchBlockSender[I, S]) SendList(state BatchState, blocks []core.RawBlock[I]) error {
+// 	// We never send block requests for empty batches.
+// 	if len(blocks) == 0 {
+// 		log.Debugw("exit", "object", "GenericRequestBatchBlockSender", "method", "SendList", "state", state, "blocks", len(blocks))
+// 		return nil
+// 	}
 
-	return bbs.sender.SendList(state, blocks)
-}
+// 	return bbs.sender.SendList(state, blocks)
+// }
 
-func (bbs *GenericRequestBatchBlockSender[I, S]) Close() error {
-	return bbs.sender.Close()
-}
+// func (bbs *GenericRequestBatchBlockSender[I, S]) Close() error {
+// 	return bbs.sender.Close()
+// }
 
-type GenericRequestBatchStatusSender[I core.BlockId] struct {
-	sender BatchStatusSender[I]
-}
+// type GenericRequestBatchStatusSender[I core.BlockId] struct {
+// 	sender BatchStatusSender[I]
+// }
 
-func NewGenericRequestBatchStatusSender[I core.BlockId](sender BatchStatusSender[I]) *GenericRequestBatchStatusSender[I] {
-	return &GenericRequestBatchStatusSender[I]{sender}
-}
+// func NewGenericRequestBatchStatusSender[I core.BlockId](sender BatchStatusSender[I]) *GenericRequestBatchStatusSender[I] {
+// 	return &GenericRequestBatchStatusSender[I]{sender}
+// }
 
-func (bss *GenericRequestBatchStatusSender[I]) SendStatus(state BatchState, have filter.Filter[I], want []I) error {
-	// For requests, we never send status messages if we already have all the blocks we want.
-	if len(want) == 0 {
-		log.Debugw("exit", "object", "GenericRequestBatchStatusSender", "method", "SendStatus", "have", have.Count(), "want", len(want))
-		return nil
-	}
+// func (bss *GenericRequestBatchStatusSender[I]) SendStatus(state BatchState, have filter.Filter[I], want []I) error {
+// 	// For requests, we never send status messages if we already have all the blocks we want.
+// 	if len(want) == 0 {
+// 		log.Debugw("exit", "object", "GenericRequestBatchStatusSender", "method", "SendStatus", "have", have.Count(), "want", len(want))
+// 		return nil
+// 	}
 
-	return bss.sender.SendStatus(state, have, want)
-}
+// 	return bss.sender.SendStatus(state, have, want)
+// }
 
-func (bss *GenericRequestBatchStatusSender[I]) Close() error {
-	return bss.sender.Close()
-}
+// func (bss *GenericRequestBatchStatusSender[I]) Close() error {
+// 	return bss.sender.Close()
+// }
 
 type GenericBatchSourceConnection[I core.BlockId] struct {
 	core.Orchestrator[BatchState]
@@ -95,8 +95,8 @@ func (conn *GenericBatchSourceConnection[I]) Sender(batchSender BatchBlockSender
 	return sender
 }
 
-func (conn *GenericBatchSourceConnection[I]) Session(store core.BlockStore[I], filter filter.Filter[I]) *core.SourceSession[I, BatchState] {
-	return instrumented.NewSourceSession[I, BatchState](store, filter, conn, conn.stats, conn.instrument)
+func (conn *GenericBatchSourceConnection[I]) Session(store core.BlockStore[I], filter filter.Filter[I], requester bool) *core.SourceSession[I, BatchState] {
+	return instrumented.NewSourceSession[I, BatchState](store, filter, conn, conn.stats, conn.instrument, requester)
 }
 
 func NewGenericBatchSourceConnection[I core.BlockId](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSourceConnection[I] {
@@ -132,8 +132,8 @@ func (conn *GenericBatchSinkConnection[I]) Sender(batchSender BatchStatusSender[
 	return sender
 }
 
-func (conn *GenericBatchSinkConnection[I]) Session(store core.BlockStore[I], accumulator core.StatusAccumulator[I]) *core.SinkSession[I, BatchState] {
-	return instrumented.NewSinkSession[I, BatchState](store, accumulator, conn, conn.stats, conn.instrument)
+func (conn *GenericBatchSinkConnection[I]) Session(store core.BlockStore[I], accumulator core.StatusAccumulator[I], requester bool) *core.SinkSession[I, BatchState] {
+	return instrumented.NewSinkSession[I, BatchState](store, accumulator, conn, conn.stats, conn.instrument, requester)
 }
 
 func NewGenericBatchSinkConnection[I core.BlockId](stats stats.Stats, instrument instrumented.InstrumentationOptions) *GenericBatchSinkConnection[I] {

--- a/batch/responder.go
+++ b/batch/responder.go
@@ -48,6 +48,8 @@ func (sr *SinkResponder[I]) SinkSessionData(sessionId SessionId) *SinkSessionDat
 		},
 	)
 
+	log.Debugw("SinkSessionData", "sessionId", sessionId, "sessionData", sessionData)
+
 	return sessionData
 }
 
@@ -166,6 +168,7 @@ func (sr *SourceResponder[I]) SourceSessionData(sessionId SessionId) *SourceSess
 			return sr.startSourceSession(sessionId)
 		},
 	)
+	log.Debugw("SourceSessionData", "sessionId", sessionId, "sessionData", sessionData)
 
 	return sessionData
 }

--- a/batch/responder.go
+++ b/batch/responder.go
@@ -74,6 +74,7 @@ func (sr *SinkResponder[I]) startSinkSession(sessionId SessionId) *SinkSessionDa
 		sr.store,
 		// Since SimpleStatusAccumulator uses mutex locks, the filter allocator just returns a non-sync filter
 		core.NewSimpleStatusAccumulator(sr.filterAllocator()),
+		false, // Not a requester
 	)
 
 	// TODO: validate that we have a batch status sender first
@@ -192,6 +193,7 @@ func (sr *SourceResponder[I]) startSourceSession(sessionId SessionId) *SourceSes
 		sr.store,
 		// TODO: SourceSession has no mutex locks for filter, so we need to wrap.  Inconsistent though and really should be cleaned up.
 		filter.NewSynchronizedFilter(sr.filterAllocator()),
+		false, // Not a requester
 	)
 
 	blockSender := sourceConnection.Sender(sr.batchBlockSender, sr.batchSize)

--- a/batch/responder.go
+++ b/batch/responder.go
@@ -37,7 +37,7 @@ func NewSinkResponder[I core.BlockId, R core.BlockIdRef[I]](store core.BlockStor
 }
 
 func (sr *SinkResponder[I, R]) newSinkConnection() *GenericBatchSinkConnection[I, R] {
-	return NewGenericBatchSinkConnection[I, R](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE)
+	return NewGenericBatchSinkConnection[I, R](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE, false) // Responders aren't requesters
 }
 
 func (sr *SinkResponder[I, R]) SinkSessionData(sessionId SessionId) *SinkSessionData[I, R] {
@@ -175,7 +175,7 @@ func NewSourceResponder[I core.BlockId, R core.BlockIdRef[I]](store core.BlockSt
 }
 
 func (sr *SourceResponder[I, R]) newSourceConnection() *GenericBatchSourceConnection[I, R] {
-	return NewGenericBatchSourceConnection[I, R](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE)
+	return NewGenericBatchSourceConnection[I, R](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE, false) // Responders aren't requesters
 }
 
 func (sr *SourceResponder[I, R]) SourceSessionData(sessionId SessionId) *SourceSessionData[I, R] {

--- a/core/accumulator.go
+++ b/core/accumulator.go
@@ -68,7 +68,7 @@ func (ssa *SimpleStatusAccumulator[I]) Receive(id I) error {
 // Send sends the current status using the given StatusSender.
 func (ssa *SimpleStatusAccumulator[I]) Send(sender StatusSender[I]) error {
 	ssa.mutex.Lock()
-	sendHave := ssa.have
+	sendHave := ssa.have.Copy()
 	sendWant := maps.Keys(ssa.want)
 	ssa.have = ssa.have.Clear() // this aways creates an empty copy
 	ssa.want = make(map[I]bool)

--- a/core/core.go
+++ b/core/core.go
@@ -305,11 +305,11 @@ type Orchestrator[F Flags] interface {
 	// IsClosed returns true if the orchestrator is closed.
 	IsClosed() bool
 
-	// ShouldClose returns true if the state of the Orchestrator indicates that the session should close.
+	// IsSafeStateToClose returns true if the state of the Orchestrator indicates that the session should close.
 	// Other factors may need to be taken into account as well to determine if close should happen, but this
 	// tells us if the states indicate a close is safe.
 	// TODO: Maybe rename to IsSafeToClose or IsSafeCloseState?
-	ShouldClose() bool
+	IsSafeStateToClose() bool
 }
 
 // SinkSession is a session that receives blocks and sends out status updates. Two type parameters
@@ -467,7 +467,7 @@ func (ss *SinkSession[I, F]) Run(
 	defer ss.orchestrator.Notify(END_SESSION)
 
 	for !ss.orchestrator.IsClosed() {
-		if ss.pendingBlocks.Len() == 0 && ss.statusAccumulator.WantCount() == 0 && ss.orchestrator.ShouldClose() {
+		if ss.pendingBlocks.Len() == 0 && ss.statusAccumulator.WantCount() == 0 && ss.orchestrator.IsSafeStateToClose() {
 			if err := ss.orchestrator.Notify(BEGIN_CLOSE); err != nil {
 				ss.doneCh <- err
 				return
@@ -659,7 +659,7 @@ func (ss *SourceSession[I, F]) Run(
 		// Note that this check means you must enqueue before running a session.
 		// TODO: Is there any need to mutex this so we get it for both variables simultaneously?
 		log.Debugw("SourceSession.Run() checking for pending blocks", "pendingBlocks", ss.pendingBlocks.Len(), "blockSender", blockSender.Len())
-		if ss.pendingBlocks.Len() == 0 && blockSender.Len() == 0 {
+		if ss.pendingBlocks.Len() == 0 && blockSender.Len() == 0 && ss.orchestrator.IsSafeStateToClose() {
 			if err := ss.orchestrator.Notify(BEGIN_CLOSE); err != nil {
 				ss.doneCh <- err
 				return
@@ -668,8 +668,6 @@ func (ss *SourceSession[I, F]) Run(
 				ss.doneCh <- err
 				return
 			}
-
-			continue
 		}
 
 		if err := ss.orchestrator.Notify(BEGIN_PROCESSING); err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -466,7 +466,7 @@ func (ss *SinkSession[I, F]) Run(
 	defer ss.orchestrator.Notify(END_SESSION)
 
 	for !ss.orchestrator.IsClosed() {
-		log.Debugw("SourceSession.Run() checking for pending blocks", "pendingBlocks", ss.pendingBlocks.Len(), "wantCount", ss.statusAccumulator.WantCount())
+		log.Debugw("SinkSession.Run() checking for pending blocks", "pendingBlocks", ss.pendingBlocks.Len(), "wantCount", ss.statusAccumulator.WantCount())
 		if ss.pendingBlocks.Len() == 0 && ss.statusAccumulator.WantCount() == 0 && ss.orchestrator.IsSafeStateToClose() {
 			if err := ss.orchestrator.Notify(BEGIN_CLOSE); err != nil {
 				ss.doneCh <- err

--- a/core/core.go
+++ b/core/core.go
@@ -325,6 +325,7 @@ type SinkSession[
 	stats             stats.Stats
 	startedCh         chan bool
 	doneCh            chan error
+	requester         bool // requester or responder
 }
 
 // Struct for returning summary information about the session. This is intended to allow implementers to
@@ -347,6 +348,7 @@ func NewSinkSession[I BlockId, F Flags](
 	statusAccumulator StatusAccumulator[I], // Accumulator for status information
 	orchestrator Orchestrator[F], // Orchestrator used to synchronize this session with its communication channel
 	stats stats.Stats, // Collector for session-related statistics
+	requester bool,
 ) *SinkSession[I, F] {
 	return &SinkSession[I, F]{
 		statusAccumulator,
@@ -356,6 +358,7 @@ func NewSinkSession[I BlockId, F Flags](
 		stats,
 		make(chan bool, 1),
 		make(chan error, 1),
+		requester,
 	}
 }
 
@@ -581,6 +584,7 @@ type SourceSession[
 	stats         stats.Stats
 	startedCh     chan bool
 	doneCh        chan error
+	requester     bool
 }
 
 // NewSourceSession creates a new SourceSession.
@@ -589,6 +593,7 @@ func NewSourceSession[I BlockId, F Flags](
 	filter filter.Filter[I], // Filter to which 'Haves' from the sink will be added
 	orchestrator Orchestrator[F], // Orchestrator used to synchronize this session with its communication channel
 	stats stats.Stats, // Collector for session-related statistics
+	requester bool, // Requester or responder
 ) *SourceSession[I, F] {
 	return &SourceSession[I, F]{
 		store,
@@ -599,6 +604,7 @@ func NewSourceSession[I BlockId, F Flags](
 		stats,
 		make(chan bool, 1),
 		make(chan error, 1),
+		requester,
 	}
 }
 

--- a/core/instrumented/instrument.go
+++ b/core/instrumented/instrument.go
@@ -48,9 +48,9 @@ func (io *Orchestrator[F]) IsClosed() bool {
 	return result
 }
 
-func (io *Orchestrator[F]) ShouldClose() bool {
-	result := io.orchestrator.ShouldClose()
-	io.stats.Logger().Debugw("exit", "method", "ShouldClose", "state", io.orchestrator.State(), "result", result)
+func (io *Orchestrator[F]) IsSafeStateToClose() bool {
+	result := io.orchestrator.IsSafeStateToClose()
+	io.stats.Logger().Debugw("exit", "method", "IsSafeStateToClose", "state", io.orchestrator.State(), "result", result)
 	return result
 }
 

--- a/core/instrumented/instrument.go
+++ b/core/instrumented/instrument.go
@@ -25,6 +25,13 @@ func NewOrchestrator[F core.Flags](orchestrator core.Orchestrator[F], stats stat
 	}
 }
 
+// IsRequester calls the underlying orchestrator's IsRequester method and records stats.
+func (io *Orchestrator[F]) IsRequester() bool {
+	result := io.orchestrator.IsRequester()
+	io.stats.Logger().Debugw("exit", "method", "IsRequester", "result", result)
+	return result
+}
+
 // Notify calls the underlying orchestrator's Notify method and records stats.
 func (io *Orchestrator[F]) Notify(event core.SessionEvent) error {
 	io.stats.Logger().Debugw("enter", "method", "Notify", "event", event, "state", io.orchestrator.State())
@@ -48,8 +55,8 @@ func (io *Orchestrator[F]) IsClosed() bool {
 	return result
 }
 
-func (io *Orchestrator[F]) IsSafeStateToClose(requester bool) bool {
-	result := io.orchestrator.IsSafeStateToClose(requester)
+func (io *Orchestrator[F]) IsSafeStateToClose() bool {
+	result := io.orchestrator.IsSafeStateToClose()
 	io.stats.Logger().Debugw("exit", "method", "IsSafeStateToClose", "state", io.orchestrator.State(), "result", result)
 	return result
 }

--- a/core/instrumented/instrument.go
+++ b/core/instrumented/instrument.go
@@ -61,6 +61,12 @@ func (io *Orchestrator[F]) IsSafeStateToClose() bool {
 	return result
 }
 
+func (io *Orchestrator[F]) ShouldFlush() bool {
+	result := io.orchestrator.ShouldFlush()
+	io.stats.Logger().Debugw("exit", "method", "ShouldFlush", "state", io.orchestrator.State(), "result", result)
+	return result
+}
+
 // BlockStore is a BlockStore that records stats for events.
 type BlockStore[I core.BlockId] struct {
 	store core.BlockStore[I]

--- a/core/instrumented/instrument.go
+++ b/core/instrumented/instrument.go
@@ -48,8 +48,8 @@ func (io *Orchestrator[F]) IsClosed() bool {
 	return result
 }
 
-func (io *Orchestrator[F]) IsSafeStateToClose() bool {
-	result := io.orchestrator.IsSafeStateToClose()
+func (io *Orchestrator[F]) IsSafeStateToClose(requester bool) bool {
+	result := io.orchestrator.IsSafeStateToClose(requester)
 	io.stats.Logger().Debugw("exit", "method", "IsSafeStateToClose", "state", io.orchestrator.State(), "result", result)
 	return result
 }

--- a/core/instrumented/instrument.go
+++ b/core/instrumented/instrument.go
@@ -269,7 +269,7 @@ const (
 	INSTRUMENT_SENDER
 )
 
-func NewSourceSession[I core.BlockId, F core.Flags](store core.BlockStore[I], filter filter.Filter[I], orchestrator core.Orchestrator[F], stats stats.Stats, options InstrumentationOptions) *core.SourceSession[I, F] {
+func NewSourceSession[I core.BlockId, F core.Flags](store core.BlockStore[I], filter filter.Filter[I], orchestrator core.Orchestrator[F], stats stats.Stats, options InstrumentationOptions, requester bool) *core.SourceSession[I, F] {
 
 	if options&INSTRUMENT_STORE != 0 {
 		store = NewBlockStore(store, stats.WithContext("SourceStore"))
@@ -279,7 +279,7 @@ func NewSourceSession[I core.BlockId, F core.Flags](store core.BlockStore[I], fi
 		filter = inf.New(filter, stats.WithContext("SourceFilter"))
 	}
 
-	return core.NewSourceSession(store, filter, orchestrator, stats)
+	return core.NewSourceSession(store, filter, orchestrator, stats, requester)
 }
 
 func NewSinkSession[I core.BlockId, F core.Flags](
@@ -288,11 +288,12 @@ func NewSinkSession[I core.BlockId, F core.Flags](
 	orchestrator core.Orchestrator[F],
 	stats stats.Stats,
 	options InstrumentationOptions,
+	requester bool,
 ) *core.SinkSession[I, F] {
 
 	if options&INSTRUMENT_STORE > 0 {
 		store = NewBlockStore(store, stats.WithContext("SinkStore"))
 	}
 
-	return core.NewSinkSession(store, statusAccumulator, orchestrator, stats)
+	return core.NewSinkSession(store, statusAccumulator, orchestrator, stats, requester)
 }

--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -469,7 +469,7 @@ func TestMockTransferToEmptyStoreSingleBatchNoDelaySend(t *testing.T) {
 }
 
 func TestMockTransferToEmptyStoreSingleBatchNoDelayReceive(t *testing.T) {
-	t.Skip("Skipping test")
+	// t.Skip("Skipping test")
 	sourceStore := mock.NewStore(mock.DefaultConfig())
 	root := mock.AddRandomTree(context.Background(), sourceStore, 10, 5, 0.0)
 	sinkStore := mock.NewStore(mock.DefaultConfig())

--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -218,7 +218,7 @@ func MockBatchTransferSend(senderStore *mock.Store, receiverStore *mock.Store, r
 
 	config := batch.Config{
 		MaxBatchSize:  maxBatchSize,
-		BloomCapacity: 1024, // matches value used below before my changes
+		BloomCapacity: 1024,
 		BloomFunction: MOCK_ID_HASH,
 		Instrument:    instrumented.INSTRUMENT_STORE | instrumented.INSTRUMENT_ORCHESTRATOR,
 	}
@@ -302,7 +302,7 @@ func MockBatchTransferSend(senderStore *mock.Store, receiverStore *mock.Store, r
 
 	go func() {
 		log.Debugf("timeout started")
-		time.Sleep(20 * time.Second)
+		time.Sleep(30 * time.Second)
 		log.Debugf("timeout elapsed")
 
 		// If we timeout, see what goroutines are hung
@@ -428,7 +428,7 @@ func MockBatchTransferReceive(sinkStore *mock.Store, sourceStore *mock.Store, ro
 
 	go func() {
 		log.Debugf("timeout started")
-		time.Sleep(20 * time.Second)
+		time.Sleep(30 * time.Second)
 		log.Debugf("timeout elapsed")
 
 		// See what goroutine is hung

--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -242,6 +242,7 @@ func MockBatchTransferSend(senderStore *mock.Store, receiverStore *mock.Store, r
 	senderSession := sourceConnection.Session(
 		senderStore,
 		filter.NewSynchronizedFilter(batch.NewBloomAllocator[mock.BlockId](&config)()),
+		true, // Requester
 	)
 
 	log.Debugf("created senderSession")
@@ -368,7 +369,8 @@ func MockBatchTransferReceive(sinkStore *mock.Store, sourceStore *mock.Store, ro
 
 	receiverSession := sinkConnection.Session(
 		NewSynchronizedBlockStore[mock.BlockId](NewSynchronizedBlockStore[mock.BlockId](sinkStore)),
-		NewSimpleStatusAccumulator[mock.BlockId](batch.NewBloomAllocator[mock.BlockId](&config)()),
+		NewSimpleStatusAccumulator(batch.NewBloomAllocator[mock.BlockId](&config)()),
+		true, // Requester
 	)
 
 	statusSender := sinkConnection.Sender(&statusChannel)

--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -333,6 +333,9 @@ func MockBatchTransferSend(senderStore *mock.Store, receiverStore *mock.Store, r
 	// }
 	// log.Debugf("receiver session terminated")
 
+	log.Debugw("waiting for all done", "sessions", len(sinkResponder.SinkSessionIds()))
+	sinkResponder.AllDone()
+
 	snapshotAfter := stats.GLOBAL_REPORTING.Snapshot()
 	diff := snapshotBefore.Diff(snapshotAfter)
 	diff.Write(&log.SugaredLogger)
@@ -448,10 +451,8 @@ func MockBatchTransferReceive(sinkStore *mock.Store, sourceStore *mock.Store, ro
 		log.Errorf("error closing status sender: %v", err)
 	}
 
-	// if err := <-sourceResponder.SourceSession(SESSION_ID).Done(); err != nil {
-	// 	log.Debugf("sender session failed: %v", err)
-	// }
-	// log.Debugf("sender session terminated")
+	log.Debugw("waiting for all done", "sessions", len(sourceResponder.SourceSessionIds()))
+	sourceResponder.AllDone()
 
 	snapshotAfter := stats.GLOBAL_REPORTING.Snapshot()
 	diff := snapshotBefore.Diff(snapshotAfter)
@@ -517,7 +518,7 @@ func TestMockTransferToEmptyStoreMultiBatchNoDelaySend(t *testing.T) {
 
 func TestMockTransferToEmptyStoreMultiBatchNoDelayReceive(t *testing.T) {
 	senderStore := mock.NewStore(mock.DefaultConfig())
-	root := mock.AddRandomTree(context.Background(), senderStore, 10, 5, 0.0)
+	root := mock.AddRandomTree(context.Background(), senderStore, 4, 5, 0.0)
 	receiverStore := mock.NewStore(mock.DefaultConfig())
 	MockBatchTransferReceive(receiverStore, senderStore, root, 50, 0, 0)
 	if !receiverStore.HasAll(root) {

--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -88,7 +88,9 @@ func (ch *BlockChannel) SendList(state batch.BatchState, blocks []RawBlock[mock.
 		time.Sleep(pause)
 		message.Read(&buf)
 	}
+	log.Debugw("sending", "object", "BlockChannel", "method", "SendList", "state", state, "blocks", len(blocks))
 	ch.channel <- message
+	log.Debugw("sent", "object", "BlockChannel", "method", "SendList", "state", state, "blocks", len(blocks))
 	return nil
 }
 
@@ -115,7 +117,8 @@ func (ch *BlockChannel) listen() error {
 			return ErrReceiverNotSet
 		}
 		log.Debugw("received", "object", "BlockChannel", "method", "listen", "state", result.State, "blocks", len(result.Car.Blocks))
-		receiver.HandleList(result.Car.Blocks)
+		err := receiver.HandleList(result.Car.Blocks)
+		log.Debugw("handled list", "object", "BlockChannel", "method", "listen", "state", result.State, "blocks", len(result.Car.Blocks), "err", err)
 	}
 	return err
 }
@@ -326,10 +329,10 @@ func MockBatchTransferSend(senderStore *mock.Store, receiverStore *mock.Store, r
 	// TODO: Replace with waiting for all channels on the sinkResponder's sessions to be done
 	// If we get here, the sender session is done, so this will get the last living sink session's status
 
-	if err := <-sinkResponder.SinkSession(SESSION_ID).Done(); err != nil {
-		log.Debugf("receiver session failed: %v", err)
-	}
-	log.Debugf("receiver session terminated")
+	// if err := <-sinkResponder.SinkSession(SESSION_ID).Done(); err != nil {
+	// 	log.Debugf("receiver session failed: %v", err)
+	// }
+	// log.Debugf("receiver session terminated")
 
 	snapshotAfter := stats.GLOBAL_REPORTING.Snapshot()
 	diff := snapshotBefore.Diff(snapshotAfter)
@@ -446,10 +449,10 @@ func MockBatchTransferReceive(sinkStore *mock.Store, sourceStore *mock.Store, ro
 		log.Errorf("error closing status sender: %v", err)
 	}
 
-	if err := <-sourceResponder.SourceSession(SESSION_ID).Done(); err != nil {
-		log.Debugf("sender session failed: %v", err)
-	}
-	log.Debugf("sender session terminated")
+	// if err := <-sourceResponder.SourceSession(SESSION_ID).Done(); err != nil {
+	// 	log.Debugf("sender session failed: %v", err)
+	// }
+	// log.Debugf("sender session terminated")
 
 	snapshotAfter := stats.GLOBAL_REPORTING.Snapshot()
 	diff := snapshotBefore.Diff(snapshotAfter)
@@ -469,7 +472,6 @@ func TestMockTransferToEmptyStoreSingleBatchNoDelaySend(t *testing.T) {
 }
 
 func TestMockTransferToEmptyStoreSingleBatchNoDelayReceive(t *testing.T) {
-	// t.Skip("Skipping test")
 	sourceStore := mock.NewStore(mock.DefaultConfig())
 	root := mock.AddRandomTree(context.Background(), sourceStore, 10, 5, 0.0)
 	sinkStore := mock.NewStore(mock.DefaultConfig())
@@ -493,7 +495,6 @@ func TestMockTransferToEmptyStoreSingleBatchDelayedSend(t *testing.T) {
 }
 
 func TestMockTransferToEmptyStoreSingleBatchDelayedReceive(t *testing.T) {
-	t.Skip("Skipping test")
 	senderStore := mock.NewStore(mock.DefaultConfig())
 	root := mock.AddRandomTree(context.Background(), senderStore, 10, 5, 0.0)
 	receiverStore := mock.NewStore(mock.DefaultConfig())
@@ -516,7 +517,6 @@ func TestMockTransferToEmptyStoreMultiBatchNoDelaySend(t *testing.T) {
 }
 
 func TestMockTransferToEmptyStoreMultiBatchNoDelayReceive(t *testing.T) {
-	t.Skip("Skipping test")
 	senderStore := mock.NewStore(mock.DefaultConfig())
 	root := mock.AddRandomTree(context.Background(), senderStore, 10, 5, 0.0)
 	receiverStore := mock.NewStore(mock.DefaultConfig())

--- a/core_test/carmirror_test.go
+++ b/core_test/carmirror_test.go
@@ -239,7 +239,7 @@ func MockBatchTransferSend(senderStore *mock.Store, receiverStore *mock.Store, r
 		latencyMs,
 	}
 
-	sourceConnection := batch.NewGenericBatchSourceConnection[mock.BlockId](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE)
+	sourceConnection := batch.NewGenericBatchSourceConnection[mock.BlockId](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE, true) // Requester
 
 	senderSession := sourceConnection.Session(
 		senderStore,
@@ -367,7 +367,7 @@ func MockBatchTransferReceive(sinkStore *mock.Store, sourceStore *mock.Store, ro
 	}
 
 	// The sink is driving for pull
-	sinkConnection := batch.NewGenericBatchSinkConnection[mock.BlockId](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE)
+	sinkConnection := batch.NewGenericBatchSinkConnection[mock.BlockId](stats.GLOBAL_STATS, instrumented.INSTRUMENT_ORCHESTRATOR|instrumented.INSTRUMENT_STORE, true) // Requester
 
 	receiverSession := sinkConnection.Session(
 		NewSynchronizedBlockStore[mock.BlockId](NewSynchronizedBlockStore[mock.BlockId](sinkStore)),

--- a/http/client.go
+++ b/http/client.go
@@ -53,6 +53,7 @@ func (c *Client[I, R]) startSourceSession(url string) *core.SourceSession[I, bat
 	newSession := sourceConnection.Session(
 		c.store,
 		filter.NewSynchronizedFilter[I](filter.NewEmptyFilter(c.allocator)),
+		true, // Requester
 	)
 
 	newSender := sourceConnection.ImmediateSender(newSession, c.maxBatchSize)
@@ -110,6 +111,7 @@ func (c *Client[I, R]) startSinkSession(url string) *core.SinkSession[I, batch.B
 	newSession := sinkConnection.Session(
 		c.store,
 		core.NewSimpleStatusAccumulator(c.allocator()),
+		true, // Requester
 	)
 
 	sender := sinkConnection.ImmediateSender(newSession)

--- a/http/client.go
+++ b/http/client.go
@@ -25,13 +25,13 @@ type Client[I core.BlockId, R core.BlockIdRef[I]] struct {
 	instrumented   instrumented.InstrumentationOptions
 }
 
-func NewClient[I core.BlockId, R core.BlockIdRef[I]](store core.BlockStore[I], config Config) *Client[I, R] {
+func NewClient[I core.BlockId, R core.BlockIdRef[I]](store core.BlockStore[I], config batch.Config) *Client[I, R] {
 	return &Client[I, R]{
 		store,
 		util.NewSynchronizedMap[string, *core.SourceSession[I, batch.BatchState]](),
 		util.NewSynchronizedMap[string, *core.SinkSession[I, batch.BatchState]](),
 		config.MaxBatchSize,
-		NewBloomAllocator[I](&config),
+		batch.NewBloomAllocator[I](&config),
 		config.Instrument,
 	}
 }

--- a/http/client.go
+++ b/http/client.go
@@ -62,11 +62,6 @@ func (c *Client[I, R]) startSourceSession(url string) *core.SourceSession[I, bat
 		log.Debugw("starting source session", "object", "Client", "method", "startSourceSession", "url", url)
 		newSession.Run(newSender)
 
-		// Close the sender
-		// if err := newSender.Close(); err != nil {
-		// 	log.Errorw("error closing sender", "object", "Client", "method", "startSourceSession", "url", url, "error", err)
-		// }
-
 		// TODO: potential race condition if Run() completes before the
 		// session is added to the list of sink sessions (which happens
 		// when startSourceSession returns)
@@ -119,11 +114,6 @@ func (c *Client[I, R]) startSinkSession(url string) *core.SinkSession[I, batch.B
 	go func() {
 		log.Debugw("starting sink session", "object", "Client", "method", "startSinkSession", "url", url)
 		newSession.Run(sender)
-
-		// TODO: close sender?
-		// if err := sender.Close(); err != nil {
-		// 	log.Errorw("error closing sender", "object", "Client", "method", "startSinkSession", "url", url, "error", err)
-		// }
 
 		// TODO: potential race condition if Run() completes before the
 		// session is added to the list of sink sessions (which happens

--- a/http/common.go
+++ b/http/common.go
@@ -3,9 +3,6 @@ package http
 import (
 	"errors"
 
-	"github.com/fission-codes/go-car-mirror/core"
-	"github.com/fission-codes/go-car-mirror/core/instrumented"
-	"github.com/fission-codes/go-car-mirror/filter"
 	golog "github.com/ipfs/go-log/v2"
 )
 
@@ -17,29 +14,11 @@ var (
 )
 
 type Config struct {
-	MaxBatchSize  uint32
-	Address       string
-	BloomCapacity uint
-	BloomFunction uint64
-	Instrument    instrumented.InstrumentationOptions
+	Address string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		MaxBatchSize:  32,
-		Address:       ":8080",
-		BloomCapacity: 1024,
-		BloomFunction: 2,
-		Instrument:    0,
-	}
-}
-
-func NewBloomAllocator[I core.BlockId](config *Config) func() filter.Filter[I] {
-	return func() filter.Filter[I] {
-		filter, err := filter.TryNewBloomFilter[I](config.BloomCapacity, config.BloomFunction)
-		if err != nil {
-			log.Errorf("Invalid hash function specified %v", config.BloomFunction)
-		}
-		return filter
+		Address: ":8080",
 	}
 }

--- a/http/connection.go
+++ b/http/connection.go
@@ -175,7 +175,7 @@ type HttpServerSourceConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 
 func NewHttpServerSourceConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions) *HttpServerSourceConnection[I, R] {
 	return &HttpServerSourceConnection[I, R]{
-		(*batch.GenericBatchSourceConnection[I, R])(batch.NewGenericBatchSourceConnection[I, R](stats, instrument)),
+		(*batch.GenericBatchSourceConnection[I, R])(batch.NewGenericBatchSourceConnection[I, R](stats, instrument, false)), // Responder
 		make(chan *messages.BlocksMessage[I, R]),
 	}
 }
@@ -199,7 +199,7 @@ type HttpServerSinkConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 
 func NewHttpServerSinkConnection[I core.BlockId, R core.BlockIdRef[I]](stats stats.Stats, instrument instrumented.InstrumentationOptions) *HttpServerSinkConnection[I, R] {
 	return &HttpServerSinkConnection[I, R]{
-		(*batch.GenericBatchSinkConnection[I, R])(batch.NewGenericBatchSinkConnection[I, R](stats, instrument)),
+		(*batch.GenericBatchSinkConnection[I, R])(batch.NewGenericBatchSinkConnection[I, R](stats, instrument, false)), // Responder
 		make(chan *messages.StatusMessage[I, R]),
 	}
 }
@@ -220,7 +220,7 @@ type HttpClientSourceConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 
 func NewHttpClientSourceConnection[I core.BlockId, R core.BlockIdRef[I]](client *http.Client, url string, stats stats.Stats, instrument instrumented.InstrumentationOptions) *HttpClientSourceConnection[I, R] {
 	return &HttpClientSourceConnection[I, R]{
-		batch.NewGenericBatchSourceConnection[I, R](stats, instrument),
+		batch.NewGenericBatchSourceConnection[I, R](stats, instrument, true), // Client is requester
 		client,
 		url,
 	}
@@ -238,7 +238,7 @@ type HttpClientSinkConnection[I core.BlockId, R core.BlockIdRef[I]] struct {
 
 func NewHttpClientSinkConnection[I core.BlockId, R core.BlockIdRef[I]](client *http.Client, url string, stats stats.Stats, instrument instrumented.InstrumentationOptions) *HttpClientSinkConnection[I, R] {
 	return &HttpClientSinkConnection[I, R]{
-		batch.NewGenericBatchSinkConnection[I, R](stats, instrument),
+		batch.NewGenericBatchSinkConnection[I, R](stats, instrument, true), // Client is requester
 		client,
 		url,
 	}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -25,8 +25,8 @@ func TestClientSend(t *testing.T) {
 		Address: ":8021",
 	}
 	responderConfig := batch.Config{
-		MaxBatchSize:  100,
-		BloomCapacity: 256,
+		MaxBatchSize:  1024,
+		BloomCapacity: 1024,
 		BloomFunction: MOCK_ID_HASH,
 		Instrument:    instrumented.INSTRUMENT_STORE | instrumented.INSTRUMENT_ORCHESTRATOR,
 	}
@@ -54,7 +54,7 @@ func TestClientSend(t *testing.T) {
 
 	go func() {
 		log.Debugf("timeout started")
-		time.Sleep(10 * time.Second)
+		time.Sleep(50 * time.Second)
 		log.Debugf("timeout elapsed")
 
 		// If we timeout, see what goroutines are hung
@@ -100,8 +100,8 @@ func TestClientReceive(t *testing.T) {
 		Address: ":8021",
 	}
 	responderConfig := batch.Config{
-		MaxBatchSize:  100,
-		BloomCapacity: 256,
+		MaxBatchSize:  1024,
+		BloomCapacity: 1024,
 		BloomFunction: MOCK_ID_HASH,
 		Instrument:    instrumented.INSTRUMENT_STORE | instrumented.INSTRUMENT_ORCHESTRATOR,
 	}
@@ -109,7 +109,7 @@ func TestClientReceive(t *testing.T) {
 	serverStore := mock.NewStore(mock.Config{})
 	clientStore := mock.NewStore(mock.Config{})
 
-	rootId := mock.AddRandomTree(context.Background(), serverStore, 2, 2, 0.0)
+	rootId := mock.AddRandomTree(context.Background(), serverStore, 12, 5, 0.0)
 
 	server := NewServer[mock.BlockId](serverStore, serverConfig, responderConfig)
 	client := NewClient[mock.BlockId](clientStore, responderConfig)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -150,7 +150,7 @@ func TestClientReceive(t *testing.T) {
 	// Wait for the session to go away
 	err := <-session.Done()
 
-	if err != ErrInvalidSession {
+	if err != nil {
 		t.Errorf("Closed with unexpected error %v", err)
 	}
 

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fission-codes/go-car-mirror/batch"
 	"github.com/fission-codes/go-car-mirror/core/instrumented"
 	"github.com/fission-codes/go-car-mirror/filter"
 	mock "github.com/fission-codes/go-car-mirror/fixtures"
 	"github.com/fission-codes/go-car-mirror/stats"
-	"github.com/fission-codes/go-car-mirror/util"
 )
 
 const MOCK_ID_HASH = 2
@@ -19,23 +19,13 @@ func init() {
 	filter.RegisterHash(MOCK_ID_HASH, mock.XX3HashBlockId)
 }
 
-func assertBytesEqual(a []byte, b []byte, t *testing.T) {
-	if len(a) != len(b) {
-		t.Errorf("Length ase different: %v, %v", len(a), len(b))
-	}
-	compareLength := util.Min(len(a), len(b))
-	var j int
-	for j = 0; j < compareLength && a[j] == b[j]; j++ {
-	}
-	if j < compareLength {
-		t.Errorf("First difference is at byte: %v", j)
-	}
-}
-
 func TestClientSend(t *testing.T) {
-	config := Config{
+	// t.Skip()
+	serverConfig := Config{
+		Address: ":8021",
+	}
+	responderConfig := batch.Config{
 		MaxBatchSize:  100,
-		Address:       ":8021",
 		BloomCapacity: 256,
 		BloomFunction: MOCK_ID_HASH,
 		Instrument:    instrumented.INSTRUMENT_STORE | instrumented.INSTRUMENT_ORCHESTRATOR,
@@ -46,8 +36,8 @@ func TestClientSend(t *testing.T) {
 
 	rootId := mock.AddRandomTree(context.Background(), clientStore, 12, 5, 0.0)
 
-	server := NewServer[mock.BlockId](serverStore, config)
-	client := NewClient[mock.BlockId](clientStore, config)
+	server := NewServer[mock.BlockId](serverStore, serverConfig, responderConfig)
+	client := NewClient[mock.BlockId](clientStore, responderConfig)
 
 	errChan := make(chan error)
 
@@ -56,15 +46,33 @@ func TestClientSend(t *testing.T) {
 	// Give the server time to start up
 	time.Sleep(100 * time.Millisecond)
 
+	snapshotBefore := stats.GLOBAL_REPORTING.Snapshot()
+
 	// TODO: get session and enqueue before starting.
-	client.Send("http://localhost:8021", rootId)
+	url := "http://localhost:8021"
+	client.Send(url, rootId)
+
+	go func() {
+		log.Debugf("timeout started")
+		time.Sleep(10 * time.Second)
+		log.Debugf("timeout elapsed")
+
+		// If we timeout, see what goroutines are hung
+		// pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+
+		if err := client.GetSourceSession(url).Cancel(); err != nil {
+			log.Errorf("error cancelling sender session: %v", err)
+		}
+
+		server.Stop()
+	}()
 
 	// Wait for the session to go away
-	info, err := client.SourceInfo("http://localhost:8021")
+	info, err := client.SourceInfo(url)
 	for err == nil {
 		log.Debugf("client info: %s", info.String())
 		time.Sleep(100 * time.Millisecond)
-		info, err = client.SourceInfo("http://localhost:8021")
+		info, err = client.SourceInfo(url)
 	}
 
 	if err != ErrInvalidSession {
@@ -77,17 +85,22 @@ func TestClientSend(t *testing.T) {
 		t.Errorf("Server closed with error %v", err)
 	}
 
+	snapshotAfter := stats.GLOBAL_REPORTING.Snapshot()
+	diff := snapshotBefore.Diff(snapshotAfter)
+	diff.Write(&log.SugaredLogger)
+
 	if !serverStore.HasAll(rootId) {
 		t.Errorf("Expected server store to have all children of %v", rootId)
 	}
 }
 
 func TestClientReceive(t *testing.T) {
-	t.Skip("TODO")
-
-	config := Config{
+	// t.Skip("TODO")
+	serverConfig := Config{
+		Address: ":8021",
+	}
+	responderConfig := batch.Config{
 		MaxBatchSize:  100,
-		Address:       ":8021",
 		BloomCapacity: 256,
 		BloomFunction: MOCK_ID_HASH,
 		Instrument:    instrumented.INSTRUMENT_STORE | instrumented.INSTRUMENT_ORCHESTRATOR,
@@ -96,10 +109,10 @@ func TestClientReceive(t *testing.T) {
 	serverStore := mock.NewStore(mock.Config{})
 	clientStore := mock.NewStore(mock.Config{})
 
-	rootId := mock.AddRandomTree(context.Background(), serverStore, 12, 5, 0.0)
+	rootId := mock.AddRandomTree(context.Background(), serverStore, 2, 2, 0.0)
 
-	server := NewServer[mock.BlockId](serverStore, config)
-	client := NewClient[mock.BlockId](clientStore, config)
+	server := NewServer[mock.BlockId](serverStore, serverConfig, responderConfig)
+	client := NewClient[mock.BlockId](clientStore, responderConfig)
 
 	errChan := make(chan error)
 
@@ -110,15 +123,32 @@ func TestClientReceive(t *testing.T) {
 
 	snapshotBefore := stats.GLOBAL_REPORTING.Snapshot()
 
-	client.Receive("http://localhost:8021", rootId)
+	url := "http://localhost:8021"
+	session := client.GetSinkSession(url)
+	go func() {
+		if err := session.Enqueue(rootId); err != nil {
+			log.Debugw("error enqueuing root", "err", err)
+			return
+		}
+	}()
+
+	go func() {
+		log.Debugf("timeout started")
+		time.Sleep(10 * time.Second)
+		log.Debugf("timeout elapsed")
+
+		// If we timeout, see what goroutines are hung
+		// pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+
+		if err := session.Cancel(); err != nil {
+			log.Errorf("error cancelling sender session: %v", err)
+		}
+
+		// server.Stop()
+	}()
 
 	// Wait for the session to go away
-	info, err := client.SinkInfo("http://localhost:8021")
-	for err == nil {
-		log.Debugf("client info: %s", info.String())
-		time.Sleep(1000 * time.Millisecond)
-		info, err = client.SinkInfo("http://localhost:8021")
-	}
+	err := <-session.Done()
 
 	if err != ErrInvalidSession {
 		t.Errorf("Closed with unexpected error %v", err)

--- a/http/server.go
+++ b/http/server.go
@@ -104,6 +104,7 @@ func (srv *Server[I, R]) startSourceSession(token SessionToken) *ServerSourceSes
 	newSession := sourceConnection.Session(
 		srv.store,
 		filter.NewSynchronizedFilter[I](filter.NewEmptyFilter(srv.allocator)),
+		false, // Server is always responder, not requester
 	)
 
 	newSender := sourceConnection.DeferredSender(srv.maxBatchSize)
@@ -219,6 +220,7 @@ func (srv *Server[I, R]) startSinkSession(token SessionToken) *ServerSinkSession
 	newSession := sourceConnection.Session(
 		srv.store,
 		core.NewSimpleStatusAccumulator(srv.allocator()),
+		false, // Server is always responder, not requester
 	)
 
 	sender := sourceConnection.DeferredSender()

--- a/http/server.go
+++ b/http/server.go
@@ -12,44 +12,40 @@ import (
 	"github.com/fission-codes/go-car-mirror/batch"
 	"github.com/fission-codes/go-car-mirror/core"
 	"github.com/fission-codes/go-car-mirror/core/instrumented"
-	"github.com/fission-codes/go-car-mirror/filter"
 	"github.com/fission-codes/go-car-mirror/messages"
 	"github.com/fission-codes/go-car-mirror/stats"
-	"github.com/fission-codes/go-car-mirror/util"
 )
 
-type SessionToken string
-
-type ServerSourceSessionData[I core.BlockId, R core.BlockIdRef[I]] struct {
-	conn    *HttpServerSourceConnection[I, R]
-	Session *core.SourceSession[I, batch.BatchState]
-}
-
-type ServerSinkSessionData[I core.BlockId, R core.BlockIdRef[I]] struct {
-	conn    *HttpServerSinkConnection[I, R]
-	Session *core.SinkSession[I, batch.BatchState]
-}
-
 type Server[I core.BlockId, R core.BlockIdRef[I]] struct {
-	store          core.BlockStore[I]
-	sourceSessions *util.SynchronizedMap[SessionToken, *ServerSourceSessionData[I, R]]
-	sinkSessions   *util.SynchronizedMap[SessionToken, *ServerSinkSessionData[I, R]]
-	maxBatchSize   uint32
-	allocator      func() filter.Filter[I]
-	http           *http.Server
-	instrumented   instrumented.InstrumentationOptions
+	store           core.BlockStore[I]
+	maxBatchSize    uint32
+	http            *http.Server
+	instrumented    instrumented.InstrumentationOptions
+	sinkResponder   *batch.SinkResponder[I]
+	sourceResponder *batch.SourceResponder[I]
 }
 
-func NewServer[I core.BlockId, R core.BlockIdRef[I]](store core.BlockStore[I], config Config) *Server[I, R] {
+// TODO: change config to something more flexible, so it can work for responder and this server.
+// We have server config and responder config, and they are different.
+// Start with 2 configs I guess
+func NewServer[I core.BlockId, R core.BlockIdRef[I]](store core.BlockStore[I], serverConfig Config, responderConfig batch.Config) *Server[I, R] {
 	server := &Server[I, R]{
 		store,
-		util.NewSynchronizedMap[SessionToken, *ServerSourceSessionData[I, R]](),
-		util.NewSynchronizedMap[SessionToken, *ServerSinkSessionData[I, R]](),
-		config.MaxBatchSize,
-		NewBloomAllocator[I](&config),
+		responderConfig.MaxBatchSize,
 		nil,
-		config.Instrument,
+		responderConfig.Instrument,
+		// TODO: Set the batchStatusSender
+		batch.NewSinkResponder[I](store, responderConfig, nil),
+		// TODO: Set the batchBlockSender
+		batch.NewSourceResponder[I](store, responderConfig, nil, responderConfig.MaxBatchSize),
 	}
+
+	sinkConn := NewHttpServerSinkConnection[I, R](stats.GLOBAL_STATS, responderConfig.Instrument)
+	server.sinkResponder.SetStatusSender(sinkConn.DeferredSender())
+
+	// sourceConn := NewHttpServerSourceConnection[I, R](stats.GLOBAL_STATS, responderConfig.Instrument)
+	// blockSender := sourceConn.DeferredSender(responderConfig.MaxBatchSize)
+	// server.sourceResponder.SetBatchBlockSender()
 
 	mux := http.NewServeMux()
 
@@ -64,12 +60,48 @@ func NewServer[I core.BlockId, R core.BlockIdRef[I]](store core.BlockStore[I], c
 	})
 
 	server.http = &http.Server{
-		Addr:           config.Address,
+		Addr:           serverConfig.Address,
 		Handler:        mux,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
+
+	// TODO
+	// Call server.sinkResponder.SetStatusSender(...)
+	// Call server.sourceResponder.SetBatchBlockSender(...)
+	// Also make sure we can receive from the other side, whatever we pass into those.
+	// This is taking the place of DeferredSender and PendingResponse.
+
+	// For send we did:
+	// senderSession := sourceConnection.Session(
+	// 	senderStore,
+	// 	filter.NewSynchronizedFilter(batch.NewBloomAllocator[mock.BlockId](&config)()),
+	// 	true, // Requester
+	// )
+	// blockSender := sourceConnection.Sender(&blockChannel, uint32(maxBatchSize))
+	// sinkResponder.SetStatusSender(&statusChannel)
+	// statusChannel.SetReceiverFunc(func() *batch.SimpleBatchStatusReceiver[mock.BlockId] {
+	//   return sourceConnection.Receiver(senderSession)
+	// })
+
+	// For receive we did:
+	// receiverSession := sinkConnection.Session(
+	// 	NewSynchronizedBlockStore[mock.BlockId](NewSynchronizedBlockStore[mock.BlockId](sinkStore)),
+	// 	NewSimpleStatusAccumulator(batch.NewBloomAllocator[mock.BlockId](&config)()),
+	// 	true, // Requester
+	// )
+	// statusSender := sinkConnection.Sender(&statusChannel)
+
+	// sourceResponder.SetBatchBlockSender(&blockChannel)
+
+	// blockChannel.SetReceiverFunc(func() batch.BatchBlockReceiver[mock.BlockId] {
+	// 	return sinkConnection.Receiver(receiverSession)
+	// })
+
+	// statusChannel.SetReceiverFunc(func() *batch.SimpleBatchStatusReceiver[mock.BlockId] {
+	// 	return sourceResponder.Receiver(SESSION_ID)
+	// })
 
 	return server
 }
@@ -86,7 +118,7 @@ func (srv *Server[I, R]) Stop() error {
 	return srv.http.Close()
 }
 
-func (srv *Server[I, R]) generateToken(remoteAddr string) SessionToken {
+func (srv *Server[I, R]) generateToken(remoteAddr string) batch.SessionId {
 	// We might at some stage do something to verify session tokens, but for now they are
 	// just 128 bit random numbers
 	token := make([]byte, 16)
@@ -94,65 +126,22 @@ func (srv *Server[I, R]) generateToken(remoteAddr string) SessionToken {
 	if err != nil {
 		panic(err)
 	}
-	return SessionToken(base64.URLEncoding.EncodeToString(token))
-}
-
-func (srv *Server[I, R]) startSourceSession(token SessionToken) *ServerSourceSessionData[I, R] {
-
-	sourceConnection := NewHttpServerSourceConnection[I, R](stats.GLOBAL_STATS.WithContext(string(token)), srv.instrumented)
-
-	newSession := sourceConnection.Session(
-		srv.store,
-		filter.NewSynchronizedFilter[I](filter.NewEmptyFilter(srv.allocator)),
-		false, // Server is always responder, not requester
-	)
-
-	newSender := sourceConnection.DeferredSender(srv.maxBatchSize)
-
-	go func() {
-		log.Debugw("starting source session", "object", "Server", "method", "startSourceSession", "token", token)
-		newSession.Run(newSender)
-
-		// TODO: potential race condition if Run() completes before the
-		// session is added to the list of sink sessions (which happens
-		// when startSourceSession returns)
-		srv.sourceSessions.Remove(token)
-		log.Debugw("source session ended", "object", "Server", "method", "startSourceSession", "token", token)
-	}()
-
-	// Wait for the session to start
-	<-newSession.Started()
-
-	return &ServerSourceSessionData[I, R]{sourceConnection, newSession}
-}
-
-func (srv *Server[I, R]) GetSourceSession(token SessionToken) *ServerSourceSessionData[I, R] {
-	if session, ok := srv.sourceSessions.Get(token); ok {
-		return session
-	} else {
-		session = srv.sourceSessions.GetOrInsert(
-			token,
-			func() *ServerSourceSessionData[I, R] {
-				return srv.startSourceSession(token)
-			},
-		)
-		return session
-	}
+	return batch.SessionId(base64.URLEncoding.EncodeToString(token))
 }
 
 func (srv *Server[I, R]) HandleStatus(response http.ResponseWriter, request *http.Request) {
 	log.Debugw("Server", "method", "HandleStatus")
 	// First get a session token from a cookie; if no such cookie exists, create one
-	var sessionToken SessionToken
-	sourceCookie, err := request.Cookie("sourceSessionToken")
+	var sessionId batch.SessionId
+	sourceCookie, err := request.Cookie("sourceSessionId")
 	if err != nil {
 		switch {
 		case errors.Is(err, http.ErrNoCookie):
 			log.Debugw("generating cookie", "object", "Server", "method", "HandleStatus")
-			sessionToken = srv.generateToken(request.RemoteAddr)
+			sessionId = srv.generateToken(request.RemoteAddr)
 			http.SetCookie(response, &http.Cookie{
-				Name:     "sourceSessionToken",
-				Value:    (string)(sessionToken),
+				Name:     "sourceSessionId",
+				Value:    (string)(sessionId),
 				Secure:   false,
 				SameSite: http.SameSiteDefaultMode,
 				MaxAge:   0,
@@ -163,48 +152,45 @@ func (srv *Server[I, R]) HandleStatus(response http.ResponseWriter, request *htt
 			return
 		}
 	} else {
-		sessionToken = SessionToken(sourceCookie.Value)
+		sessionId = batch.SessionId(sourceCookie.Value)
 	}
-	log.Debugw("have session token", "object", "Server", "method", "HandleStatus", "token", sessionToken)
-
-	// Find the session from the session token, or create one
-	sourceSession := srv.GetSourceSession(sessionToken)
-	// TODO: If the session can't be looked up, this will be a new session.  Is this desired?
-	log.Debugw("have session for token", "object", "Server", "method", "HandleStatus", "session", sessionToken)
+	log.Debugw("have session token", "object", "Server", "method", "HandleStatus", "token", sessionId)
 
 	// Parse the request to get the status message
-	message := messages.StatusMessage[I, R, batch.BatchState]{}
+	message := messages.StatusMessage[I, R]{}
 	messageReader := bufio.NewReader(request.Body)
 	if err := message.Read(messageReader); err != nil {
-		log.Errorw("parsing status message", "object", "Server", "method", "HandleStatus", "session", sessionToken, "error", err)
+		log.Errorw("parsing status message", "object", "Server", "method", "HandleStatus", "session", sessionId, "error", err)
 		http.Error(response, "bad message format", http.StatusBadRequest)
 		return
 	}
 
 	if len(message.Want) == 0 {
-		log.Debugw("received status message with no wants", "object", "Server", "method", "HandleStatus", "session", sessionToken, "message", message)
+		log.Debugw("received status message with no wants", "object", "Server", "method", "HandleStatus", "session", sessionId, "message", message)
 		http.Error(response, "bad message format", http.StatusBadRequest)
 		return
 	}
 
-	// TODO: Even if the want list is greater than 0, we might get 0 blocks back.
-
-	// Send the status message to the session
 	// TODO: Handle errors
-
-	// I confirmed that HandleStatus can safely be called before session is running.
-	sourceSession.conn.Receiver(sourceSession.Session).HandleStatus(message.State, message.Have.Any(), message.Want)
+	// sourceSession.conn.Receiver(sourceSession.Session).HandleStatus(message.State, message.Have.Any(), message.Want)
+	if err := srv.sourceResponder.Receiver(sessionId).HandleStatus(message.Have.Any(), message.Want); err != nil {
+		log.Errorw("handling status message", "object", "Server", "method", "HandleStatus", "session", sessionId, "error", err)
+		http.Error(response, "server error", http.StatusInternalServerError)
+		return
+	}
 	request.Body.Close()
 
 	// Wait for a response from the session
-	log.Debugw("waiting on session", "object", "Server", "method", "HandleStatus", "session", sessionToken)
+	log.Debugw("waiting on session", "object", "Server", "method", "HandleStatus", "session", sessionId)
 	// TODO: In the past this call hung due to reading from a channel with no sender.
-	blocks := sourceSession.conn.PendingResponse()
-	log.Debugw("session returned blocks", "object", "Server", "method", "HandleStatus", "len", len(blocks.Car.Blocks))
+	// blocks := srv.sourceResponder.SourceConnection(sessionId).PendingResponse()
+
+	// blocks := sourceSession.conn.PendingResponse()
+	// log.Debugw("session returned blocks", "object", "Server", "method", "HandleStatus", "len", len(blocks.Car.Blocks))
 
 	// Write the response
 	response.WriteHeader(http.StatusAccepted)
-	err = blocks.Write(response)
+	// err = blocks.Write(response)
 
 	if err != nil {
 		log.Errorf("unexpected error writing response", "object", "Server", "method", "HandleStatus", "error", err)
@@ -212,62 +198,19 @@ func (srv *Server[I, R]) HandleStatus(response http.ResponseWriter, request *htt
 	log.Debugw("exit", "object", "Server", "method", "HandleStatus")
 }
 
-func (srv *Server[I, R]) startSinkSession(token SessionToken) *ServerSinkSessionData[I, R] {
-
-	// This variable is named wrong.  It's sink, not source
-	sourceConnection := NewHttpServerSinkConnection[I, R](stats.GLOBAL_STATS.WithContext(string(token)), srv.instrumented)
-
-	newSession := sourceConnection.Session(
-		srv.store,
-		core.NewSimpleStatusAccumulator(srv.allocator()),
-		false, // Server is always responder, not requester
-	)
-
-	sender := sourceConnection.DeferredSender()
-
-	go func() {
-		newSession.Run(sender)
-		srv.sinkSessions.Remove(token)
-	}()
-
-	// Wait for the session to start
-	<-newSession.Started()
-
-	return &ServerSinkSessionData[I, R]{
-		sourceConnection,
-		newSession,
-	}
-}
-
-func (srv *Server[I, R]) GetSinkSession(token SessionToken) *ServerSinkSessionData[I, R] {
-	// Note as currently coded, if we get the session by token, we know it is still running.
-	if session, ok := srv.sinkSessions.Get(token); ok {
-		log.Debugw("found session", "object", "Server", "method", "GetSinkSession", "token", token)
-		return session
-	} else {
-		session = srv.sinkSessions.GetOrInsert(
-			token,
-			func() *ServerSinkSessionData[I, R] {
-				return srv.startSinkSession(token)
-			},
-		)
-		return session
-	}
-}
-
 func (srv *Server[I, R]) HandleBlocks(response http.ResponseWriter, request *http.Request) {
 	log.Debugw("enter", "object", "Server", "method", "HandleBlocks")
 	// First get a session token from a cookie; if no such cookie exists, create one
-	var sessionToken SessionToken
-	sinkCookie, err := request.Cookie("sinkSessionToken")
+	var sessionId batch.SessionId
+	sinkCookie, err := request.Cookie("sinkSessionId")
 	if err != nil {
 		switch {
 		case errors.Is(err, http.ErrNoCookie):
 			log.Debugw("generating cookie", "object", "Server", "method", "HandleBlocks")
-			sessionToken = srv.generateToken(request.RemoteAddr)
+			sessionId = srv.generateToken(request.RemoteAddr)
 			http.SetCookie(response, &http.Cookie{
-				Name:     "sinkSessionToken",
-				Value:    (string)(sessionToken),
+				Name:     "sinkSessionId",
+				Value:    (string)(sessionId),
 				Secure:   false,
 				SameSite: http.SameSiteDefaultMode,
 				MaxAge:   0,
@@ -278,67 +221,63 @@ func (srv *Server[I, R]) HandleBlocks(response http.ResponseWriter, request *htt
 			return
 		}
 	} else {
-		sessionToken = SessionToken(sinkCookie.Value)
+		sessionId = batch.SessionId(sinkCookie.Value)
 	}
-	log.Debugw("have session token", "object", "Server", "method", "HandleBlocks", "token", sessionToken)
-
-	// Find the session from the session token, or create one
-	// TODO: Use GetOrInsert with a closure to avoid potentially spinning off sessions that are never closed
-	sinkSession := srv.GetSinkSession(sessionToken)
-	log.Debugw("have session for token", "object", "Server", "method", "HandleBlocks", "session", sessionToken)
+	log.Debugw("have session token", "object", "Server", "method", "HandleBlocks", "token", sessionId)
 
 	// Parse the request to get the blocks message
-	message := messages.BlocksMessage[I, R, batch.BatchState]{}
+	message := messages.BlocksMessage[I, R]{}
 	messageReader := bufio.NewReader(request.Body)
 	// TODO: i/o timeout here, leads to BadRequest being returned
 	if err := message.Read(messageReader); err != io.EOF {
-		log.Errorw("parsing blocks message", "object", "Server", "method", "HandleBlocks", "session", sessionToken, "error", err)
+		log.Errorw("parsing blocks message", "object", "Server", "method", "HandleBlocks", "session", sessionId, "error", err)
 		http.Error(response, "bad message format", http.StatusBadRequest)
 		return
 	}
 	request.Body.Close()
 
-	log.Debugw("processed blocks", "object", "Server", "method", "HandleBlocks", "session", sessionToken, "count", len(message.Car.Blocks))
+	log.Debugw("processed blocks", "object", "Server", "method", "HandleBlocks", "session", sessionId, "count", len(message.Car.Blocks))
 
 	// Send the blocks to the sessions
-	err = sinkSession.conn.Receiver(sinkSession.Session).HandleList(message.Car.Blocks)
+	// err = sinkSession.conn.Receiver(sinkSession.Session).HandleList(message.Car.Blocks)
+	err = srv.sinkResponder.Receiver(sessionId).HandleList(message.Car.Blocks)
 	if err != nil {
-		log.Errorw("could not handle block list", "object", "server", "method", "HandleBlocks", "session", sessionToken, "error", err)
+		log.Errorw("could not handle block list", "object", "server", "method", "HandleBlocks", "session", sessionId, "error", err)
 	}
 
 	// Wait for a response from the session
-	log.Debugw("waiting on session", "object", "Server", "method", "HandleBlocks", "session", sessionToken)
-	status := sinkSession.conn.PendingResponse()
-	log.Debugw("session returned status", "object", "Server", "method", "HandleBlocks", "status", status)
+	log.Debugw("waiting on session", "object", "Server", "method", "HandleBlocks", "session", sessionId)
+	// status := srv.sinkResponder.SinkConnection(sessionId).PendingResponse()
+	// log.Debugw("session returned status", "object", "Server", "method", "HandleBlocks", "status", status)
 
 	// Write the response
 	response.WriteHeader(http.StatusAccepted)
-	err = status.Write(response)
+	// err = status.Write(response)
 	if err != nil {
 		log.Errorf("unexpected error writing response", "object", "Server", "method", "HandleBlocks", "error", err)
 	}
 	log.Debugw("exit", "object", "Server", "method", "HandleBlocks")
 }
 
-func (srv *Server[I, R]) SourceSessions() []SessionToken {
-	return srv.sourceSessions.Keys()
+func (srv *Server[I, R]) SourceSessions() []core.SourceSession[I, batch.BatchState] {
+	return nil
 }
 
-func (srv *Server[I, R]) SourceInfo(token SessionToken) (*core.SourceSessionInfo[batch.BatchState], error) {
-	if session, ok := srv.sourceSessions.Get(token); ok {
-		return session.Session.Info(), nil
+func (srv *Server[I, R]) SinkSessions() []core.SinkSession[I, batch.BatchState] {
+	return nil
+}
+
+func (srv *Server[I, R]) SinkInfo(token batch.SessionId) (*core.SinkSessionInfo[batch.BatchState], error) {
+	if session := srv.sinkResponder.SinkSession(token); session != nil {
+		return session.Info(), nil
 	} else {
 		return nil, ErrInvalidSession
 	}
 }
 
-func (srv *Server[I, R]) SinkSessions() []SessionToken {
-	return srv.sinkSessions.Keys()
-}
-
-func (srv *Server[I, R]) SinkInfo(token SessionToken) (*core.SinkSessionInfo[batch.BatchState], error) {
-	if session, ok := srv.sinkSessions.Get(token); ok {
-		return session.Session.Info(), nil
+func (srv *Server[I, R]) SourceInfo(token batch.SessionId) (*core.SourceSessionInfo[batch.BatchState], error) {
+	if session := srv.sourceResponder.SourceSession(token); session != nil {
+		return session.Info(), nil
 	} else {
 		return nil, ErrInvalidSession
 	}

--- a/messages/message_test.go
+++ b/messages/message_test.go
@@ -116,17 +116,14 @@ func TestBlocksMessageReadWrite(t *testing.T) {
 	buf := bytes.Buffer{}
 	blocks := make([]core.RawBlock[mock.BlockId], 1)
 	blocks[0] = mock.RandMockBlock()
-	message := NewBlocksMessage(uint(23), blocks)
+	message := NewBlocksMessage(blocks)
 
 	if err := message.Write(&buf); err != nil {
 		t.Errorf("Error writing archive, %v", err)
 	}
-	message2 := BlocksMessage[mock.BlockId, *mock.BlockId, uint]{}
+	message2 := BlocksMessage[mock.BlockId, *mock.BlockId]{}
 	if err := message2.Read(&buf); err != io.EOF {
 		t.Errorf("Error reading archive, %v", err)
-	}
-	if message.State != message2.State {
-		t.Errorf("State is not same, %v != %v", message.State, message2.State)
 	}
 	if !reflect.DeepEqual(message.Car.Header, message.Car.Header) {
 		t.Errorf("Archive Headers are no longer equal after transport")
@@ -144,17 +141,14 @@ func TestStatusMessageReadWrite(t *testing.T) {
 		t.Errorf("Error creating bloom filter, %v", err)
 	}
 
-	message := NewStatusMessage[mock.BlockId](uint(23), have, want)
+	message := NewStatusMessage[mock.BlockId](have, want)
 
 	if err := message.Write(&buf); err != nil {
 		t.Errorf("Error writing status, %v", err)
 	}
-	message2 := StatusMessage[mock.BlockId, *mock.BlockId, uint]{}
+	message2 := StatusMessage[mock.BlockId, *mock.BlockId]{}
 	if err := message2.Read(&buf); err != nil {
 		t.Errorf("Error reading filter, %v", err)
-	}
-	if message.State != message2.State {
-		t.Errorf("State is not same, %v != %v", message.State, message2.State)
 	}
 	if !message.Have.Any().Equal(message2.Have.Any()) {
 		t.Errorf("have lists no longer equal after transport")


### PR DESCRIPTION
A bunch of changes to get to a point where push and pull over http both work, meaning they transfer the requested blocks and don't hang.  Much cleanup is needed, but now we can start from working and have tests to run as we refactor.

- Rename enqueuing to enqueueing and add source enqueueing, which was missing
- Rename ShouldClose to IsSafeStateToClose, and define for source, including the new enqueueing state
- Wrap filterAllocator result in SynchronizedFilter to avoid race condition
- Remove SynchronizedFilter wrapping from NewSimpleStatusAccumulator call, since it already has mutex logic have.Copy to avoid race condition
- Other race condition fixes
- Move where we notify BEGIN_FLUSH and END_FLUSH, to avoid BATCH being nested within it only for http but not for others.  Led to some ugly hacks that need cleanup, but starting here with "it works" before cleanup.
- Add AllDone to be able to wait on all responder sessions.
- Add necessary logic for conditional flush
- Remove state from messages
- Add responders to http server, for the current idea that responder sessions aren't truly sessions, they're request handlers.
- Update event loop logic to close the "session" after responding, since no more processing is possible with no request to respond to.  Streaming will need to change this of course.